### PR TITLE
Set default permission mode to `auto`

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -27,7 +27,7 @@
     "refreshInterval": 5
   },
   "permissions": {
-    "defaultMode": "plan",
+    "defaultMode": "auto",
     "allow": [
       "Bash(bundle exec rspec*)",
       "Bash(bundle exec rubocop*)",


### PR DESCRIPTION
**What**:

1. Switch `permissions.defaultMode` from `plan` to `auto` in `claude/settings.json`, the dotfile source `setup/agentic.sh` deploys to `$HOME/.claude/settings.json`.

**Why**:

A `claude doctor` health check found the default permission mode set to `plan`; switching to `auto` lets a safety classifier approve routine actions instead of requiring plan mode every session.