### PR TITLE
Fix `Archive Utility` delete-after-expand preference key

### DIFF
--- a/utilities/system.sh
+++ b/utilities/system.sh
@@ -33,9 +33,12 @@ apply_system_configuration() {
     log_info "Saving screenshots in lossless 'PNG' format..."
     defaults write com.apple.screencapture type -string "png"
 
-    # Move archive to `Trash` after expanding it in `Archive Utility`.
-    log_info "Moving archive to 'Trash' after expanding in 'Archive Utility'..."
-    defaults write com.apple.archiveutility dearchive-move-after -string "~/.Trash"
+    # Delete archive after expanding it in `Archive Utility`.
+    log_info "Deleting archive after expanding in 'Archive Utility'..."
+    archive_utility_plist="$HOME/Library/Containers/com.apple.archiveutility/Data/Library/Preferences/com.apple.archiveutility"
+    mkdir -p "$(dirname "$archive_utility_plist")"
+    defaults write "$archive_utility_plist" dearchive-move-after-location -dict Selection Delete
+    killall cfprefsd 2>/dev/null || true
 
     # Show scroll-bars always.
     log_info "Showing scroll-bars always..."


### PR DESCRIPTION
**What**:

1. Writes directly to Archive Utility's sandboxed container plist path instead of the bare `com.apple.archiveutility` domain, which silently failed to write on modern macOS.
2. Switches the key from `dearchive-move-after` to `dearchive-move-after-location`'s `Selection` dict, the actual key driving post-expansion behavior, set to `Delete` to permanently delete archives after expansion.
3. Flushes `cfprefsd` after the write so the setting is picked up immediately.

**Why**:

The original `defaults write com.apple.archiveutility dearchive-move-after -string "~/.Trash"` failed outright with "Could not write domain" on sandboxed Archive Utility, and even when pointed at the correct container path, the string key alone had no effect. Root-caused by inspecting Archive Utility's Settings UI via System Events and diffing the plist for each "After expanding" option, then confirming with real zip extraction tests.

**Testing**:

1. Set `Selection = UseSameFolder` with the old string key present: archive was not moved or deleted, confirming the original approach was silently broken.
2. Set `Selection = MoveToTrash`: extracted archive was moved to `~/.Trash`.
3. Set `Selection = Delete` (the fix): extracted archive was permanently removed, not present in `~/.Trash`.