### PR TITLE
Fix macOS `Finder`, `sound`, and `Dock` preference-write bugs

### DIFF
--- a/utilities/dock.sh
+++ b/utilities/dock.sh
@@ -61,10 +61,6 @@ apply_dock_configuration() {
     log_info "Disabling animation when opening applications..."
     defaults write com.apple.dock launchanim -bool false
 
-    # Disable animation when opening applications.
-    log_info "Disabling animation when opening applications..."
-    defaults write com.apple.dock launchanim -bool false
-
     # Automatically hide and show the `Dock`.
     log_info "Automatically hiding and showing the 'Dock'..."
     sudo defaults write /Library/Preferences/com.apple.dock autohide -bool true

--- a/utilities/finder.sh
+++ b/utilities/finder.sh
@@ -36,7 +36,7 @@ apply_finder_configuration() {
 
     # Show all hidden files.
     log_info "Showing all hidden files in 'Finder' windows..."
-    defaults write com.apple.Finder AppleShowAllFiles true
+    defaults write com.apple.finder AppleShowAllFiles -bool true
 
     # Show hidden `/Volumes` and `~/Library` folders.
     log_info "Showing hidden '/Volumes' and '~/Library' folders in 'Finder' windows..."
@@ -55,7 +55,7 @@ apply_finder_configuration() {
 
     # Group files by Date creation date in `Finder`.
     log_info "Grouping files by creation date in 'Finder'..."
-    defaults write com.apple.Finder FXPreferredGroupBy dateCreated
+    defaults write com.apple.finder FXPreferredGroupBy -string "dateCreated"
 
     # Stop `.DS_Store` creation at network shares and removable drives.
     log_info "Stopping '.DS_Store' creation at network shares and removable drives..."

--- a/utilities/sound.sh
+++ b/utilities/sound.sh
@@ -31,7 +31,7 @@ apply_sound_configuration() {
 
     # Disable speech recognition
     log_info "Disabling speech recognition..."
-    sudo defaults write "com.apple.speech.recognition.AppleSpeechRecognition.prefs" StartSpeakableItems -bool false
+    defaults write "com.apple.speech.recognition.AppleSpeechRecognition.prefs" StartSpeakableItems -bool false
 
     # Stop `iTunes` from responding to the keyboard media keys.
     log_info "Stopping 'iTunes' from responding to the keyboard media keys..."


### PR DESCRIPTION
**What**:

1. Fixes `com.apple.finder AppleShowAllFiles` and `FXPreferredGroupBy` writes to use the correct lowercase domain and explicit `-bool`/`-string` type flags. The domain case only breaks on a case-sensitive-formatted APFS volume, not on the default case-insensitive one, but the untyped writes genuinely stored plain strings instead of real booleans.
2. Removes the incorrect `sudo` from the speech recognition preference write in `sound.sh`. `com.apple.speech.recognition.AppleSpeechRecognition.prefs` is a per-user domain, so `sudo` wrote it into root's home instead of the actual user's.
3. Removes a duplicated `launchanim` block in `dock.sh`.

**Why**:

Follow-up from auditing the repo after fixing the `Archive Utility` sandboxed-preference bug. Same bug class, `defaults write` calls that silently do nothing or land in the wrong place.

**Testing**:

1. `bash -n` on all three edited scripts.
2. `shellcheck` on all three, no new warnings beyond pre-existing unrelated ones.
3. Verified `com.apple.finder AppleShowAllFiles` and `FXPreferredGroupBy` writes land with the correct type via `defaults read` + `plutil -p` round-trip.
4. Verified the speech recognition write lands in the current user's domain without `sudo` via `defaults read`.