### PR TITLE
Stop plans and subagent prompts from skipping skills

### DIFF
--- a/.config/agentic/instructions/standards.md
+++ b/.config/agentic/instructions/standards.md
@@ -169,6 +169,13 @@ This applies in Plan Mode too. Invoking a matching skill is a read-only action, 
 
 This applies no matter which skill or command is currently driving the session, `/scope`, `/code`, `/test`, another skill's workflow, or a subagent chain, none of these override or suppress a different skill's coverage.
 
+When writing a plan step or a subagent/delegation prompt for a skill-covered action, name the skill to invoke, never the raw command it wraps. Spelling out the exact CLI flags in a plan or subagent prompt bypasses the skill, because whoever executes that step just runs the literal instruction instead of re-matching triggers. This holds even when the flags already look correct, knowing the flags is exactly what makes it tempting to skip the skill.
+
+- Wrong: plan step 'Push the branch and open a PR via `gh pr create` with a Summary/Test plan body.'
+- Right: plan step 'Push the branch, then invoke the `manage-github-pr` skill to open the PR.'
+- Wrong: subagent prompt 'Open a PR with `gh pr create --title "..." --body "## Summary..."`.'
+- Right: subagent prompt 'When your fix is committed, invoke the `manage-github-pr` skill to open the PR, do not run `gh pr create` directly.'
+
 ## Safety
 
 - Confirm before destructive operations (`rm`, `DROP TABLE`, `DELETE FROM`, etc.).

--- a/.config/agentic/skills/manage-github-pr/SKILL.md
+++ b/.config/agentic/skills/manage-github-pr/SKILL.md
@@ -12,6 +12,7 @@ description: Use for GitHub pull requests, creating a new PR with a full safety-
 - User asks to comment on or edit an existing PR, its labels, assignees, reviewers, title, or body, or to approve it or leave a quick review comment via `gh pr review`.
 - Not for just reading/viewing a PR, see the `read-github-pr` skill for that.
 - Not for a full multi-agent code review (architecture and quality sub-agents, synthesized findings report), see the `review-github-pr` skill for that.
+- Also applies when a plan step or a delegated subagent prompt already specifies `gh pr create`/`gh pr edit` directly, invoke this skill instead of running that command as written, even if the flags look complete.
 
 ## Reviewing, commenting, or editing an existing PR
 


### PR DESCRIPTION
**What**:

1. Add a rule to `standards.md` requiring plan steps and subagent/delegation prompts to name the skill to invoke for a skill-covered action, never the raw command it wraps, with wrong/right examples.
2. Add a bullet to `manage-github-pr`'s `SKILL.md` covering the case where a plan step or subagent prompt already specifies `gh pr create`/`gh pr edit` directly.

**Why**:

Two sessions (arch-tuner, containers) produced PRs with wrong titles, bodies, and missing labels because a written plan step or subagent prompt hard-coded `gh pr create` instead of invoking the `manage-github-pr` skill.