### PR TITLE
Open links with CTRL/Globe+Click in WezTerm

### DIFF
--- a/.config/wezterm/keybindings.lua
+++ b/.config/wezterm/keybindings.lua
@@ -40,6 +40,7 @@ end
 --   CTRL/Globe+Right/Left square brackets: Switch to previous/next tab.
 --   CTRL/Globe+Left/Right arrow: Move cursor to beginning/end of line (sends CTRL+A/E).
 --   Mouse left click: Copy selection to clipboard and primary selection.
+--   CTRL/Globe+Mouse left click: Open the link or URL under the cursor.
 return function(config)
     local is_macos = wezterm.target_triple:find("apple") ~= nil
     local mod = is_macos and "CMD" or "CTRL"
@@ -105,4 +106,24 @@ return function(config)
             ),
         },
     }
+
+    -- `mouse_reporting` defaults to `false`, so a binding without it only applies outside
+    -- programs that enable mouse tracking (`Claude Code`, `OpenCode`, `vim`, `tmux`). Register
+    -- both variants so CTRL/Globe+Click opens links everywhere.
+    for _, mouse_reporting in ipairs({ false, true }) do
+        table.insert(config.mouse_bindings, {
+            event = { Up = { streak = 1, button = "Left" } },
+            mods = "SUPER",
+            mouse_reporting = mouse_reporting,
+            action = wezterm.action.OpenLinkAtMouseCursor,
+        })
+        table.insert(config.mouse_bindings, {
+            -- Without this, WezTerm still forwards the `Down` half of the click
+            -- to the running program, which can trigger unwanted behavior there.
+            event = { Down = { streak = 1, button = "Left" } },
+            mods = "SUPER",
+            mouse_reporting = mouse_reporting,
+            action = wezterm.action.Nop,
+        })
+    end
 end


### PR DESCRIPTION
**What**:

1. Add explicit mouse bindings so CTRL/Globe+Click opens links via `OpenLinkAtMouseCursor`, registered for both `mouse_reporting` states so it works both at a plain shell and inside programs that enable terminal mouse tracking (`Claude Code`, `Opencode`, `vim`, `tmux`).

**Why**:

Physical Ctrl+Click didn't open links in WezTerm, the config only had a plain-click override with no modifier-based way to open links.

**Testing**:

1. Verified `wezterm.lua` loads without errors via `wezterm ls-fonts`.
2. Confirmed Ctrl+Click opens a URL at a plain shell prompt.
3. Confirmed Ctrl+Click opens a URL while inside Claude Code (mouse-reporting active).