### PR TITLE
Improve `WezTerm` bindings and PR labeling

### DIFF
--- a/.config/agentic/skills/manage-github-pr/SKILL.md
+++ b/.config/agentic/skills/manage-github-pr/SKILL.md
@@ -270,14 +270,20 @@ pr_number=$(echo "$pr_url" | grep -oE '/pull/[0-9]+$' | grep -oE '[0-9]+')
 
 #### Labels
 
+Resolve the canonical repo explicitly first. A local `origin` URL left over from a GitHub rename or transfer can silently resolve `gh pr list` to the wrong or an empty repo, with no error, unlike `gh pr create`/`push`, which do surface a "repository moved" warning. Never rely on implicit repo resolution for this step.
+
+```bash
+repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+```
+
 Fetch labels from the last 10 PRs created by the current user and apply any that appear in at least 2 of them. Never create new labels.
 
 ```bash
 # Find common labels across the last 10 PRs.
-gh pr list --author @me --state all --limit 10 --json labels \
+gh pr list --repo "$repo" --author @me --state all --limit 10 --json labels \
   --jq '.[].labels[].name' | sort | uniq -c | sort -rn | awk '$1 >= 2 {print $2}' | \
   while read label; do
-    gh pr edit "$pr_number" --add-label "$label"
+    gh pr edit "$pr_number" --repo "$repo" --add-label "$label"
   done
 ```
 

--- a/.config/wezterm/keybindings.lua
+++ b/.config/wezterm/keybindings.lua
@@ -25,11 +25,37 @@ local function close_pane_if_multiple(window, pane)
     end
 end
 
+-- The OS clipboard has no text flavor when it holds only an image, so an empty/failed
+-- read here means "not text", not necessarily "empty clipboard".
+local function clipboard_has_text(is_macos)
+    local read_command = is_macos
+        and { "pbpaste" }
+        or { "bash", "-lc", "wl-paste --no-newline 2>/dev/null || xclip -selection clipboard -o 2>/dev/null" }
+
+    local success, stdout = wezterm.run_child_process(read_command)
+    return success and stdout ~= nil and #stdout > 0
+end
+
+-- Paste clipboard text directly, or forward the raw `CTRL+V` keystroke when the
+-- clipboard holds an image, so the running program (`Claude Code`, `OpenCode`) can
+-- read the image straight from the OS clipboard itself.
+local function paste_action(is_macos)
+    return wezterm.action_callback(
+        function(window, pane)
+            if clipboard_has_text(is_macos) then
+                window:perform_action(wezterm.action.PasteFrom("Clipboard"), pane)
+            else
+                window:perform_action(wezterm.action.SendKey { key = "v", mods = "CTRL" }, pane)
+            end
+        end
+    )
+end
+
 -- WezTerm keybindings:
 -- For external keyboards and Linux systems we are going to use CTRL.
 -- For internal macOS keyboards we are going to use Globe, which is remapped to CMD.
 --   CTRL/Globe+C: Copy selection if present, else send `SIGINT` to terminal.
---   CTRL/Globe+V: Paste from clipboard.
+--   CTRL/Globe+V: Paste clipboard text or image.
 --   CTRL/Globe+D: Split pane horizontally.
 --   CTRL/Globe+T: New terminal tab.
 --   CTRL/Globe+N: New terminal window.
@@ -54,7 +80,7 @@ return function(config)
         {
             key = "v",
             mods = mod,
-            action = wezterm.action.PasteFrom("Clipboard")
+            action = paste_action(is_macos)
         },
         {
             key = "d",
@@ -133,6 +159,6 @@ return function(config)
             mods = "SUPER",
             mouse_reporting = true,
             action = wezterm.action.Nop,
-        }
+        },
     }
 end

--- a/.config/wezterm/keybindings.lua
+++ b/.config/wezterm/keybindings.lua
@@ -105,25 +105,34 @@ return function(config)
                 "ClipboardAndPrimarySelection"
             ),
         },
-    }
-
-    -- `mouse_reporting` defaults to `false`, so a binding without it only applies outside
-    -- programs that enable mouse tracking (`Claude Code`, `OpenCode`, `vim`, `tmux`). Register
-    -- both variants so CTRL/Globe+Click opens links everywhere.
-    for _, mouse_reporting in ipairs({ false, true }) do
-        table.insert(config.mouse_bindings, {
+        -- `mouse_reporting` defaults to `false`, so a binding without it only applies outside
+        -- programs that enable mouse tracking (`Claude Code`, `OpenCode`, `vim`, `tmux`). Register
+        -- both variants so CTRL/Globe+Click opens links everywhere.
+        {
             event = { Up = { streak = 1, button = "Left" } },
             mods = "SUPER",
-            mouse_reporting = mouse_reporting,
+            mouse_reporting = false,
             action = wezterm.action.OpenLinkAtMouseCursor,
-        })
-        table.insert(config.mouse_bindings, {
+        },
+        {
             -- Without this, WezTerm still forwards the `Down` half of the click
             -- to the running program, which can trigger unwanted behavior there.
             event = { Down = { streak = 1, button = "Left" } },
             mods = "SUPER",
-            mouse_reporting = mouse_reporting,
+            mouse_reporting = false,
             action = wezterm.action.Nop,
-        })
-    end
+        },
+        {
+            event = { Up = { streak = 1, button = "Left" } },
+            mods = "SUPER",
+            mouse_reporting = true,
+            action = wezterm.action.OpenLinkAtMouseCursor,
+        },
+        {
+            event = { Down = { streak = 1, button = "Left" } },
+            mods = "SUPER",
+            mouse_reporting = true,
+            action = wezterm.action.Nop,
+        }
+    }
 end


### PR DESCRIPTION
**What**:

1. Expand the mouse binding loop into explicit entries for clarity.
2. Forward CTRL/Globe+V to the running program when the clipboard holds an image, so `Claude Code` and `OpenCode` can read it directly, instead of always trying to paste clipboard text.
3. Resolve the canonical repo explicitly in the `manage-github-pr` skill's label-fetch step, instead of relying on the local `origin` URL.

**Why**:

Physical Ctrl+V couldn't paste images into `Claude Code` or `OpenCode`, the config always tried to paste clipboard text and swallowed the keystroke either way. Separately, this repo's `origin` URL is stale after a GitHub rename, which made the label-fetch step silently return empty results with no error while creating the PRs for the two fixes above.

**Testing**:

1. Confirmed `wezterm.lua` loads without errors via `wezterm ls-fonts` after each commit.
2. Copied text and confirmed Ctrl+V still pastes it normally.
3. Copied an image and confirmed Ctrl+V now triggers image paste inside Claude Code.
4. Reproduced the stale-remote label bug directly, confirmed the fixed command resolves the correct repo via `gh repo view`.