### PR TITLE
Automate reduce motion, trackpad, and keyboard shortcut setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,6 @@ Opinionated `macOS` configuration via shell scripts.
 
 - Disable **`True Tone`**
 
-`System Settings → Accessibility → Display`:
-
-- Enable **Reduce motion**
-
 ### `Finder`
 
 Open `Finder` and configure sidebar:

--- a/README.md
+++ b/README.md
@@ -95,12 +95,6 @@ Opinionated `macOS` configuration via shell scripts.
 | Command | Option |
 | Option | Control |
 
-**Shortcuts** (`System Settings → Keyboard → Keyboard Shortcuts`):
-
-- **Mission Control** → Disable all (conflicts with `AeroSpace`)
-- **Spotlight** → Enable only `Show Spotlight search` → `Key 2 + .`
-- **Input Sources** → Enable only `Select previous input source` → `Key 2 + Space`
-
 ### Display
 
 `System Settings → Displays`:

--- a/README.md
+++ b/README.md
@@ -101,12 +101,6 @@ Opinionated `macOS` configuration via shell scripts.
 - **Spotlight** → Enable only `Show Spotlight search` → `Key 2 + .`
 - **Input Sources** → Enable only `Select previous input source` → `Key 2 + Space`
 
-### Trackpad
-
-`System Settings → Trackpad → More Gestures`:
-
-- Disable **Swipe between full-screen applications** (conflicts with `SwipeAeroSpace`)
-
 ### Display
 
 `System Settings → Displays`:

--- a/utilities/appearance.sh
+++ b/utilities/appearance.sh
@@ -37,6 +37,12 @@ apply_appearance_configuration() {
     log_info "Disabling 'Click to wallpaper to reveal desktop'..."
     defaults write com.apple.WindowManager EnableStandardClickToShowDesktop -bool false
 
+    # Enable `Reduce motion`. Requires Accessibility access for `Terminal`
+    # (see README Pre-Installation), guarded so a missing grant doesn't abort the rest of this script.
+    log_info "Enabling 'Reduce motion'..."
+    defaults write com.apple.universalaccess reduceMotion -bool true || log_warning "Failed to enable 'Reduce motion', check Accessibility permission for 'Terminal'."
+    defaults write com.apple.Accessibility ReduceMotionEnabled -bool true || true
+
     log_success "Appearance configuration applied successfully."
     log_divider
 }

--- a/utilities/keyboard.sh
+++ b/utilities/keyboard.sh
@@ -50,8 +50,62 @@ apply_keyboard_configuration() {
     keyboard_clear_hidutil_mappings
     keyboard_apply_special_key_mappings
 
+    # Configure keyboard shortcuts (Mission Control, Spotlight, Input Source).
+    keyboard_apply_symbolic_hotkeys
+
     log_success "Keyboard configuration applied successfully."
     log_divider
+}
+
+# Function to configure keyboard shortcuts via `AppleSymbolicHotKeys`.
+# Disables all `Mission Control` shortcuts and sets `Show Spotlight search`/`Select the previous input source`
+# to `Key 2 + .` / `Key 2 + Space`.
+#
+# Usage:
+#   keyboard_apply_symbolic_hotkeys
+keyboard_apply_symbolic_hotkeys() {
+    log_info "Configuring keyboard shortcuts..."
+
+    local symbolic_hotkeys_plist="$HOME/Library/Preferences/com.apple.symbolichotkeys.plist"
+
+    # Disable all `Mission Control` shortcuts (each pair is the default-key /
+    # dedicated-key variant):
+    #   32/34 Mission Control, 33/35 Application windows, 36/37 Show Desktop,
+    #   79/80 Move left a space, 81/82 Move right a space, 118-121 Switch to Desktop 1-4.
+    log_info "Disabling all 'Mission Control' shortcuts..."
+    for hotkey_id in 32 33 34 35 36 37 79 80 81 82 118 119 120 121; do
+        /usr/libexec/PlistBuddy -c "Delete :AppleSymbolicHotKeys:${hotkey_id}" "$symbolic_hotkeys_plist" 2>/dev/null || true
+        /usr/libexec/PlistBuddy -c "Add :AppleSymbolicHotKeys:${hotkey_id}:enabled bool false" "$symbolic_hotkeys_plist"
+    done
+
+    # Set `Show Spotlight search` to `Key 2 + .` (physical Control key, remapped to Option).
+    log_info "Setting 'Show Spotlight search' shortcut to 'Key 2 + .'..."
+    /usr/libexec/PlistBuddy -c "Delete :AppleSymbolicHotKeys:64" "$symbolic_hotkeys_plist" 2>/dev/null || true
+    /usr/libexec/PlistBuddy \
+        -c "Add :AppleSymbolicHotKeys:64:enabled bool true" \
+        -c "Add :AppleSymbolicHotKeys:64:value:type string standard" \
+        -c "Add :AppleSymbolicHotKeys:64:value:parameters array" \
+        -c "Add :AppleSymbolicHotKeys:64:value:parameters:0 integer 46" \
+        -c "Add :AppleSymbolicHotKeys:64:value:parameters:1 integer 47" \
+        -c "Add :AppleSymbolicHotKeys:64:value:parameters:2 integer 524288" \
+        "$symbolic_hotkeys_plist"
+
+    # Set `Select the previous input source` to `Key 2 + Space` (physical Control key, remapped to Option).
+    log_info "Setting 'Select the previous input source' shortcut to 'Key 2 + Space'..."
+    /usr/libexec/PlistBuddy -c "Delete :AppleSymbolicHotKeys:60" "$symbolic_hotkeys_plist" 2>/dev/null || true
+    /usr/libexec/PlistBuddy \
+        -c "Add :AppleSymbolicHotKeys:60:enabled bool true" \
+        -c "Add :AppleSymbolicHotKeys:60:value:type string standard" \
+        -c "Add :AppleSymbolicHotKeys:60:value:parameters array" \
+        -c "Add :AppleSymbolicHotKeys:60:value:parameters:0 integer 32" \
+        -c "Add :AppleSymbolicHotKeys:60:value:parameters:1 integer 49" \
+        -c "Add :AppleSymbolicHotKeys:60:value:parameters:2 integer 524288" \
+        "$symbolic_hotkeys_plist"
+
+    killall cfprefsd 2>/dev/null || true
+
+    log_warning "Keyboard shortcut changes require logging out (or restarting) to take effect."
+    log_success "Keyboard shortcuts configured successfully."
 }
 
 # Function to clear existing hidutil mappings and launch agent.

--- a/utilities/trackpad.sh
+++ b/utilities/trackpad.sh
@@ -38,6 +38,15 @@ apply_trackpad_configuration() {
     log_info "Disabling 'Dictionary' pop-up when right-clicking..."
     defaults write com.apple.finder FXEnableDictionary -bool false
 
+    # Disable swipe between full-screen applications.
+    log_info "Disabling swipe between full-screen applications..."
+    defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadThreeFingerHorizSwipeGesture -int 0
+    defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadFourFingerHorizSwipeGesture -int 0
+    defaults write com.apple.AppleMultitouchTrackpad TrackpadThreeFingerHorizSwipeGesture -int 0
+    defaults write com.apple.AppleMultitouchTrackpad TrackpadFourFingerHorizSwipeGesture -int 0
+    defaults -currentHost write NSGlobalDomain com.apple.trackpad.threeFingerHorizSwipeGesture -int 0
+    defaults -currentHost write NSGlobalDomain com.apple.trackpad.fourFingerHorizSwipeGesture -int 0
+
     log_success "Trackpad configuration applied successfully."
     log_divider
 }


### PR DESCRIPTION
**What**:

1. Enables Reduce Motion via `com.apple.universalaccess`/`com.apple.Accessibility` in `utilities/appearance.sh`.
2. Disables swipe between full-screen applications in `utilities/trackpad.sh`, matching the existing multi-domain corner-click pattern.
3. Adds `keyboard_apply_symbolic_hotkeys` to `utilities/keyboard.sh`: disables the Mission Control `AppleSymbolicHotKeys` IDs and sets Spotlight / select-previous-input-source to `Key 2 + .` / `Key 2 + Space`.
4. Removes the now-automated items from the `README.md` Post-Installation checklist.

**Why**:

Reduce the manual steps left after `./install.sh` runs.

**Testing**:

1. Applied each new `defaults write`/`PlistBuddy` change directly on a machine that already had these settings configured by hand, and confirmed via `defaults read` / a byte-for-byte plist diff that the result is identical to the existing, working configuration.
2. Verified `bash -n` and `shellcheck` pass on all three modified scripts.

**Out of scope**:

Investigated automating Finder sidebar entries, but `sfltool add-item` no longer exists on current macOS and the `mysides` alternative is a deprecated, disabled Homebrew cask — left manual. TCC permissions, True Tone, 1Password internal settings, and Chrome PWA install were also left manual (no safe/reliable CLI path).