### PR TITLE
Fix post-install script bugs

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -50,11 +50,11 @@ fi
 log_divider
 
 # Restore installed applications' configurations.
-sh setup/applications.sh
+bash setup/applications.sh
 log_divider
 
 # Configure shell.
-sh setup/shell.sh
+bash setup/shell.sh
 
 # Configure `macOS` Preferences.
-sh setup/preferences.sh
+bash setup/preferences.sh

--- a/install.sh
+++ b/install.sh
@@ -22,14 +22,14 @@ mkdir -p ~/.config && cp -R .config/* ~/.config/
 
 # Set up agentic configuration: inject models, symlink shared content.
 log_info "Setting up agentic configuration..."
-sh "$INSTALL_SCRIPT_DIRECTORY/setup/agentic.sh"
+bash "$INSTALL_SCRIPT_DIRECTORY/setup/agentic.sh"
 
 # Give execute permission to all scripts in the directory.
 chmod +x ~/.config/scripts/*.sh
 
 # Configure `macOS`.
 log_info "Starting 'macOS' configuration..."
-sh "$INSTALL_SCRIPT_DIRECTORY/configure.sh"
+bash "$INSTALL_SCRIPT_DIRECTORY/configure.sh"
 
 log_success "System configuration completed!"
 

--- a/utilities/appearance.sh
+++ b/utilities/appearance.sh
@@ -23,7 +23,7 @@ apply_appearance_configuration() {
         mkdir -p ~/Pictures/wallpapers
     fi
     cp -R Wallpapers/* ~/Pictures/wallpapers/
-    osascript -e 'tell application "System Events" to tell every desktop to set picture to POSIX file "~/Pictures/wallpapers/rocks_milky_stream.png"'
+    osascript -e "tell application \"System Events\" to tell every desktop to set picture to POSIX file \"$HOME/Pictures/wallpapers/rocks_milky_stream.png\""
 
     # Set dark mode.
     log_info "Setting dark mode..."

--- a/utilities/system.sh
+++ b/utilities/system.sh
@@ -117,11 +117,10 @@ apply_system_configuration() {
 
     # Remove leftover user/library data for deleted apps.
     log_info "Removing leftover Library data for deleted apps..."
-    for dir in "~/Library/Containers/com.apple.voicememos" "~/Library/Containers/com.apple.garageband" "~/Library/Containers/com.apple.iMovie" "~/Library/Containers/com.apple.iWork.Keynote"; do
-        eval expanded_dir=$dir
-        if [ -d "$expanded_dir" ]; then
-            rm -rf "$expanded_dir"
-            log_info "Removed $expanded_dir."
+    for dir in "$HOME/Library/Containers/com.apple.voicememos" "$HOME/Library/Containers/com.apple.garageband" "$HOME/Library/Containers/com.apple.iMovie" "$HOME/Library/Containers/com.apple.iWork.Keynote"; do
+        if [ -d "$dir" ]; then
+            rm -rf "$dir"
+            log_info "Removed $dir."
         fi
     done
 

--- a/utilities/system.sh
+++ b/utilities/system.sh
@@ -107,7 +107,11 @@ apply_system_configuration() {
     for app in "GarageBand" "iMovie" "Keynote" "Voice Memos"; do
         # Check /Applications first.
         if [ -d "/Applications/$app.app" ]; then
-            sudo rm -rf "/Applications/$app.app" 2>/dev/null && log_info "Removed $app.app from /Applications." || log_info "Could not remove $app.app from /Applications."
+            if sudo rm -rf "/Applications/$app.app" 2>/dev/null; then
+                log_info "Removed $app.app from /Applications."
+            else
+                log_info "Could not remove $app.app from /Applications."
+            fi
         fi
     done
 


### PR DESCRIPTION
**What**:

1. Fix `~` not expanding inside the `osascript` wallpaper command in `utilities/appearance.sh`. AppleScript's `POSIX file` doesn't resolve `~`, so the call failed and, under `set -e`, silently aborted the rest of the appearance configuration (dark mode, accent color, Reduce Motion) every time.
2. Invoke bash-shebang setup scripts with `bash` instead of `sh` in `install.sh`/`configure.sh`, removing the reliance on macOS's `/bin/sh` happening to be bash in compatibility mode.
3. Replace the `A && B || C` anti-pattern in the app-removal fallback in `utilities/system.sh` with an explicit `if`/`else`, so a failing `log_info` couldn't also trigger the failure branch.
4. Replace the `eval`-based `~` expansion in the leftover-app-data cleanup loop with plain `$HOME` paths.

**Why**:

The appearance script's wallpaper step aborted silently before dark mode, accent color, or Reduce Motion ever applied.

**Testing**:

1. Ran `bash -n` on every edited script, no syntax errors.
2. Ran `shellcheck` on all edited scripts, no `SC2015`/`SC2154`/tilde-in-quotes warnings remain (only pre-existing informational `SC1091` notices).
3. Manually re-ran the fixed `osascript` wallpaper command after copying wallpapers to `~/Pictures/wallpapers`, confirmed exit code `0` (it previously failed with a broken file reference).