### PR TITLE
Drop numbered list from single-item PR `What` section

### DIFF
--- a/.config/agentic/skills/manage-github-pr/SKILL.md
+++ b/.config/agentic/skills/manage-github-pr/SKILL.md
@@ -187,6 +187,8 @@ Follow style in `~/.config/agentic/instructions/communication.md` for tone and f
 
 Derive each section:
 - What: From commit messages and diffs. Each logical change gets one plain-sentence item starting with the action verb, no `**Topic**:` label prefix. Fold migrations into the feature item they support, never list separately.
+  - If there is only one logical change, write it as a single plain sentence directly under `**What**:`, no numbered list, no leading `1.`.
+  - Use a numbered list only when there are two or more items.
 - Why: If the user provides a task, issue or tracker link:
   - CORRECT: `Resolves [1234](https://link.example.com/1234).`
   - WRONG: `Resolves [1234](https://link.example.com/1234). After this change ...`


### PR DESCRIPTION
**What**:

Drops the numbered list from the PR body `What` section when there is only one logical change.

**Why**:

A single-item `What` was still rendered as a numbered `1.` list, which reads oddly for a one-line change.