### PR TITLE
Ban backticks in Phabricator task titles

### DIFF
--- a/.config/agentic/skills/manage-phabricator-task/SKILL.md
+++ b/.config/agentic/skills/manage-phabricator-task/SKILL.md
@@ -54,7 +54,7 @@ If `error_code` is not null, token/auth is invalid and must be fixed first.
 ### 1. Gather required fields
 
 - Tag, required: Phabricator project. Ask: "Which tag?"
-- Title, required: Short imperative phrase, max ~60 characters. No priority prefix, priority is a separate field. Example: `Add dark mode toggle`.
+- Title, required: Short imperative phrase, max ~60 characters. No priority prefix, priority is a separate field. Do not wrap words in backticks, unlike commit messages, Phabricator titles are plain text. Example: Add dark mode toggle.
 
 ### 2. Gather optional fields
 


### PR DESCRIPTION
**What**:

Note that Phabricator task titles must not use backticks, since titles render as plain text, unlike commit messages.

**Why**:

Commit-message backtick conventions for technical identifiers don't apply to Phabricator titles.