### PR TITLE
Document `Google Drive` access, automate `Finder` sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Opinionated `macOS` configuration via shell scripts.
 Open `Finder` and configure sidebar:
 
 - Remove: Recents, Shared, `iCloud`, `AirDrop`
-- Add to Locations: `/` (`root`), `Home` folder
+- Add to Locations: `Home` folder
 - Add to Favorites: `Developer` folder
 
 ### `1Password`

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Opinionated `macOS` configuration via shell scripts.
 | `AeroSpace` | | ✓ | | |
 | `DockDoor` | | ✓ | ✓ | |
 | `Flameshot` | | | ✓ | |
+| `Google Drive` | | ✓ | | |
 | `Maccy` | | ✓ | | |
 | `SwipeAeroSpace` | | ✓ | | |
 

--- a/utilities/finder.sh
+++ b/utilities/finder.sh
@@ -85,6 +85,10 @@ apply_finder_configuration() {
     log_info "Disabling the warning when changing a file extension..."
     defaults write com.apple.finder FXEnableExtensionChangeWarning -bool false
 
+    # Show hard disks (including '/') under 'Finder' sidebar Locations.
+    log_info "Showing hard disks under 'Finder' sidebar Locations..."
+    defaults write com.apple.sidebarlists systemitems -dict-add ShowHardDisks -bool true
+
     log_success "'Finder' configuration applied successfully."
     log_divider
 }


### PR DESCRIPTION
**What**:

1. **Permissions doc**: Add `Google Drive` to the App Permissions table (Accessibility), verified via the app's own bundled help string about its real-time presence overlay.
2. **Finder sidebar**: Automate showing hard disks (including `/`) under Finder sidebar Locations via `defaults write com.apple.sidebarlists`, and drop that step from the manual README instructions.

**Why**:

The App Permissions table was missing an installed app that needs Accessibility access, and part of the Finder sidebar setup was manual despite being scriptable natively.

**Testing**:

1. Verified `Google Drive`'s Accessibility requirement via `Info.plist`/binary inspection of the installed app bundle.
2. Ran `apply_finder_configuration` on a real machine, confirmed `ShowHardDisks` is set correctly and the step is idempotent on rerun.