### PR TITLE
Fix set -e exit on first login item added

### DIFF
--- a/utilities/system.sh
+++ b/utilities/system.sh
@@ -173,7 +173,7 @@ apply_system_configuration() {
             if ! osascript -e 'tell application "System Events" to get the name of every login item' | sed 's/, /\n/g' | grep -Fxq "$application"; then
                 log_info "Adding '$application' to 'Login Items'..."
                 osascript -e "tell application \"System Events\" to make login item at end with properties {name: \"$application\", path:\"/Applications/$application.app\", hidden:true}"
-                ((items_to_add++))
+                items_to_add=$((items_to_add + 1))
             fi
         fi
     done


### PR DESCRIPTION
**What**:

Replace `((items_to_add++))` with `items_to_add=$((items_to_add + 1))` in `apply_system_configuration()`'s Login Items loop.

**Why**:

`((items_to_add++))` is a post-increment whose arithmetic expression evaluates to 0 (the pre-increment value) the first time an item is added, which bash treats as a failing exit status. Under the repo's `set -e`, this silently killed `install.sh` right after the first successful `osascript ... make login item ...` call, with no error output.

**Testing**:

1. `bash -n utilities/system.sh` to confirm no syntax errors.
2. Reproduced the bug and fix in isolation:
   - `bash -c 'set -e; items_to_add=0; echo before; ((items_to_add++)); echo after'` → only prints `before`, exits 1.
   - Same with `items_to_add=$((items_to_add + 1))` → prints both `before` and `after`.