### PR TITLE
Fix DockDoor window switcher orientation and settings restore

### DIFF
--- a/settings/com.ethanbills.DockDoor.plist.xml
+++ b/settings/com.ethanbills.DockDoor.plist.xml
@@ -6,14 +6,8 @@
 	<true/>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
-	<key>SUHasLaunchedBefore</key>
-	<true/>
-	<key>SULastCheckTime</key>
-	<date>2026-08-14T06:46:48Z</date>
 	<key>SUSendProfileInfo</key>
 	<false/>
-	<key>SUUpdateGroupIdentifier</key>
-	<integer>2302344179</integer>
 	<key>UserKeybind</key>
 	<string>{"keyCode":48,"modifierFlags":262401}</string>
 	<key>allowDynamicImageSizing</key>
@@ -62,21 +56,10 @@
 	<false/>
 	<key>instantWindowSwitcher</key>
 	<true/>
-	<key>lastKnownScreenRecordingPermission</key>
-	<true/>
-	<key>launched</key>
-	<true/>
 	<key>lockedDockScreenIdentifier</key>
 	<string>Optional(1)-1800.0-1169.0-Optional(8)-Optional("NSCalibratedRGBColorSpace")</string>
 	<key>mouseFollowsFocusMode</key>
 	<string>always</string>
-	<key>persistedWindowOrder</key>
-	<array>
-		<string>{"bundleIdentifier":"com.ethanbills.DockDoor","creationTime":808382095.708643,"lastAccessedTime":808382796.502113,"windowTitle":""}</string>
-		<string>{"bundleIdentifier":"com.microsoft.VSCode","creationTime":808382075.27432,"lastAccessedTime":808382719.186826,"windowTitle":"Change Switch with the following package • Untitled-1 — macsify"}</string>
-		<string>{"bundleIdentifier":"com.google.Chrome","creationTime":808382639.883355,"lastAccessedTime":808382666.962227,"windowTitle":"Transporter responses - Grafana - Pinned - Google Chrome - Christos (Work)"}</string>
-		<string>{"bundleIdentifier":"com.tinyspeck.slackmacgap","creationTime":808382075.381839,"lastAccessedTime":808382569.149919,"windowTitle":"* Unread Messages - skroutz - 1 new item - Slack"}</string>
-	</array>
 	<key>reopenSettingsAfterRestart</key>
 	<false/>
 	<key>showActiveAppIndicator</key>
@@ -113,6 +96,8 @@
 	<string>topLeading</string>
 	<key>windowSwitcherPlacementStrategy</key>
 	<string>screenWithMouse</string>
+	<key>windowSwitcherScrollDirection</key>
+	<string>horizontal</string>
 	<key>windowSwitcherSortOrder</key>
 	<string>creationOrder</string>
 </dict>


### PR DESCRIPTION
**What**:

1. **Window switcher orientation**: Add the `windowSwitcherScrollDirection` key, set to `horizontal` — DockDoor defaults this to vertical when the key is absent, which was making the Alt+Tab switcher render vertically.
2. **Settings restore**: Strip runtime/telemetry keys that shouldn't have been checked in as static config — `SUHasLaunchedBefore`, `SULastCheckTime`, `SUUpdateGroupIdentifier` (Sparkle updater session state), `lastKnownScreenRecordingPermission` (recomputed by DockDoor from the actual OS permission at every launch), `launched` (gates DockDoor's first-run onboarding in `AppDelegate.swift`, so restoring it as `true` on a fresh machine silently skipped the onboarding flow that prompts for Accessibility/Screen Recording permissions), and `persistedWindowOrder` (live window-session history, was also leaking real window titles from the exporting machine).

**Why**:

Running `install.sh` on a fresh machine left DockDoor with a broken window switcher (vertical instead of horizontal) and missing Accessibility/Screen Recording permissions, because the checked-in plist was a raw preferences export rather than curated static config.

**Testing**:

1. `plutil -lint` on the edited plist.
2. Verified against DockDoor's source (`ejbills/DockDoor`) that `windowSwitcherScrollDirection` and the `launched`/permission-gating logic behave as described.
3. Reproduced end-to-end on this machine: quit DockDoor, restored the plist, relaunched, granted Screen Recording, confirmed the switcher renders horizontally.

**Related**:

A separate DockDoor bug was found while testing this (window switcher fails to bring a window into view when it's the only app open and the current AeroSpace workspace is empty, since AeroSpace never learns about the focus change). That's an upstream DockDoor issue, not fixable from this repo's config, fix proposed at [ejbills/DockDoor#1564](https://github.com/ejbills/DockDoor/pull/1564).