### PR TITLE
Match manage-github-pr labels to PR content, not history

### DIFF
--- a/.config/agentic/skills/manage-github-pr/SKILL.md
+++ b/.config/agentic/skills/manage-github-pr/SKILL.md
@@ -278,18 +278,28 @@ Resolve the canonical repo explicitly first. A local `origin` URL left over from
 repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
 ```
 
-Fetch labels from the last 10 PRs created by the current user and apply any that appear in at least 2 of them. Never create new labels.
+Classify from this PR's own title and commit messages, never from label frequency in past PRs, that only reflects what happened to be common recently, not what this PR is. Works on the very first PR in a repo, since it doesn't depend on any label history. Only apply labels that already exist in the repo, never create new ones.
 
 ```bash
-# Find common labels across the last 10 PRs.
-gh pr list --repo "$repo" --author @me --state all --limit 10 --json labels \
-  --jq '.[].labels[].name' | sort | uniq -c | sort -rn | awk '$1 >= 2 {print $2}' | \
-  while read label; do
-    gh pr edit "$pr_number" --repo "$repo" --add-label "$label"
-  done
+# Existing labels only, never create new ones. Avoid `mapfile`/arrays,
+# this must run under whatever `sh` a hook or CI step invokes, not just
+# an interactive bash 4+ shell.
+existing_labels="$(gh label list --repo "$repo" --json name --jq '.[].name')"
+has_label() { echo "$existing_labels" | grep -qx "$1"; }
+
+# Classify from this PR's own title and commit messages.
+subject="$(gh pr view "$pr_number" --repo "$repo" --json title,commits \
+  --jq '[.title, (.commits[].messageHeadline)] | join(" ")' | tr '[:upper:]' '[:lower:]')"
+
+echo "$subject" | grep -qE 'fix|bug' && has_label bug && \
+  gh pr edit "$pr_number" --repo "$repo" --add-label bug
+echo "$subject" | grep -qE 'add|implement|support|introduce' && has_label enhancement && \
+  gh pr edit "$pr_number" --repo "$repo" --add-label enhancement
+echo "$subject" | grep -qE 'doc|readme' && has_label documentation && \
+  gh pr edit "$pr_number" --repo "$repo" --add-label documentation
 ```
 
-If no labels appear in ≥ 2 recent PRs, skip labels entirely.
+If none of these match, or the repo has none of these labels, skip labels entirely.
 
 ### 9. Summary
 


### PR DESCRIPTION
**What**:

Replaces the `manage-github-pr` skill's label step, which picked labels by frequency across the author's last 10 PRs, with one that classifies from the current PR's own title and commit messages.

**Why**:

The old step had a broken `awk 'a >= 2 {print PR}'` line, `a`/`PR` were plain undefined awk variables rather than `$1`/`$2` field references, so the condition was always false and no label was ever applied, on any repo, regardless of history. Even fixed, frequency-based selection is the wrong signal: it reapplies whatever was common recently rather than reflecting what the current PR actually is, and never applies anything on a repo with no label history yet. Found while auditing why PRs across two other projects kept coming out unlabeled this session.

**Testing**:

1. Extracted the classification snippet standalone and ran it against three sample PR titles, `fix outbox double dispatch race` matched only `bug`, `add rate limiting to the api` matched only `enhancement`, `correct stale example in readme` matched only `documentation`, and a non-matching title (`refactor internal helper naming`) correctly applied nothing.