### PR TITLE
Enable Claude Code Concise output style

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -3,6 +3,7 @@
   "model": "sonnet",
   "effortLevel": "high",
   "theme": "dark",
+  "outputStyle": "Concise",
   "includeCoAuthoredBy": false,
   "preferredNotifChannel": "terminal_bell",
   "spinnerTipsEnabled": false,


### PR DESCRIPTION
**What**:

Adds `"outputStyle": "Concise"` to `claude/settings.json` so Claude Code responses lead with the result and skip preamble, applied automatically to every machine provisioned from this repo.

**Why**:

`Concise` is a native Claude Code output style (confirmed via official docs), this wires it into the existing settings template that already flows through `setup/agentic.sh` on install.